### PR TITLE
fix uv_signal_start EINVAL error

### DIFF
--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -32,16 +32,12 @@ import { staticFiles } from "./Platform.js"
 const EFFECT_HANDLER = Symbol.for("@typed/core/Node/EffectHandler")
 const EFFECT_UPGRADE_HANDLER_TYPEID = Symbol.for("@typed/core/Node/EffectUpgradeHandler")
 
-const ALL_PROCESS_INTERRUPTS = [
+const PROCESSABLE_INTERRUPTS = [
   "SIGINT",
   "SIGTERM",
   "SIGQUIT",
   "SIGHUP",
   "SIGBREAK",
-  "SIGUSR1",
-  "SIGUSR2",
-  "SIGKILL",
-  "SIGSTOP",
   "SIGTSTP",
   "SIGTTIN",
   "SIGTTOU"
@@ -304,7 +300,7 @@ export const run = <A, E>(
     fiber.unsafeInterruptAsFork(fiber.id())
   }
 
-  ALL_PROCESS_INTERRUPTS.forEach((signal) => process.once(signal, onDispose))
+  PROCESSABLE_INTERRUPTS.forEach((signal) => process.once(signal, onDispose))
 
   if (import.meta.hot) {
     import.meta.hot.dispose(onDispose)


### PR DESCRIPTION
removed:
"SIGUSR1", <-- interferes with nodejs debug
"SIGUSR2", <-- won't kill process
"SIGKILL", <-- causes EINVAL error
"SIGSTOP", <-- causes EINVAL error

reference:
https://github.com/nodejs/node-v0.x-archive/issues/6339
https://nodejs.org/api/process.html#process_signal_events
